### PR TITLE
modifications to David's net core 3.0 fork to get unit tests to pass

### DIFF
--- a/src/Vts.MonteCarlo.CommandLineApplication.Test/Vts.MonteCarlo.CommandLineApplication.Test.csproj
+++ b/src/Vts.MonteCarlo.CommandLineApplication.Test/Vts.MonteCarlo.CommandLineApplication.Test.csproj
@@ -13,6 +13,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Vts.MonteCarlo.CommandLineApplication\Vts.MonteCarlo.CommandLineApplication.csproj" />
+    <EmbeddedResource Include="Resources\infile_unit_test_one_layer_ROfRho_Mus_only.txt" />
+    <EmbeddedResource Include="Resources\infile_unit_test_one_layer_ROfRho_Musp_and_Mus_inconsistent.txt" />
+    <EmbeddedResource Include="Resources\infile_unit_test_one_layer_ROfRho_Musp_only.txt" />
     <ProjectReference Include="..\Vts\Vts.csproj" />
   </ItemGroup>
 

--- a/src/Vts/MonteCarlo/Extensions/SimulationInputExtensions.cs
+++ b/src/Vts/MonteCarlo/Extensions/SimulationInputExtensions.cs
@@ -25,7 +25,7 @@ namespace Vts.MonteCarlo.Extensions
             var result = data.Clone();
 
             // append sweep value to the output name
-            result.OutputName += ("_" + inputParameter + "_" + String.Format("{0:g}", value));
+            result.OutputName += ("_" + inputParameter + "_" + String.Format("{0:G15}", value));
 
             var parameterString = inputParameter.ToLower().TrimEnd("0123456789".ToCharArray());
             var regionString = inputParameter.Substring(parameterString.Length);


### PR DESCRIPTION
Modified SimulationInputExtensions WithValue to format the OutputName using G15 instead of g.  Also added files in Vts.MonteCarlo.CommandLineApplication.Test/Resources to be embedded resources.